### PR TITLE
Remove lingering jQuery methods

### DIFF
--- a/angular-cloudinary.js
+++ b/angular-cloudinary.js
@@ -376,7 +376,7 @@ angularModule.provider('cloudinary', function () {
 			if (typeof(transformation) == 'string') {
 				base_transformations.push("t_" + transformation);
 			} else {
-				base_transformations.push(generate_transformation_string($.extend({}, transformation)));
+				base_transformations.push(generate_transformation_string(angular.extend({}, transformation)));
 			}
 		}
 		return base_transformations;
@@ -473,7 +473,7 @@ angularModule.provider('cloudinary', function () {
 		angle: function(angle){ return build_array(angle).join("."); },
 		background: function(background) { return background.replace(/^#/, 'rgb:');},
 		border: function(border) {
-			if ($.isPlainObject(border)) {
+			if (border != null && Object.prototype.toString.call(border) === "[object Object]") {
 				var border_width = "" + (border.width || 2);
 				var border_color = (border.color || "black").replace(/^#/, 'rgb:');
 				border = border_width + "px_solid_" + border_color;


### PR DESCRIPTION
Sharing the changes I had to make locally in order use the library with no dependencies.

Replace $.extend() with angular.extend() on line 379.

Replace $.isPlainObject(border) with border != null && Object.prototype.toString.call(border) === "[object Object]" on line 476.
